### PR TITLE
policy: Attempt BSS transitions without disassociation_imminent first

### DIFF
--- a/ubus.c
+++ b/ubus.c
@@ -430,6 +430,9 @@ usteer_ubus_get_connected_clients(struct ubus_context *ctx, struct ubus_object *
 			blobmsg_add_u64(&b, "last-kick", si->roam_kick ? current_time - si->roam_kick : 0);
 			blobmsg_add_u64(&b, "scan_start", si->roam_scan_start ? current_time - si->roam_scan_start : 0);
 			blobmsg_add_u64(&b, "scan_timeout_start", si->roam_scan_timeout_start ? current_time - si->roam_scan_timeout_start : 0);
+			blobmsg_add_u32(&b, "transition_request_count", si->transition_request_count);
+			blobmsg_add_u64(&b, "transition_request_start", si->transition_request_start ? current_time - si->transition_request_start : 0);
+			blobmsg_add_u64(&b, "transition_request_last", si->transition_request_last ? current_time - si->transition_request_last : 0);
 			blobmsg_close_table(&b, t);
 
 			t = blobmsg_open_table(&b, "bss-transition-response");

--- a/usteer.h
+++ b/usteer.h
@@ -267,6 +267,9 @@ struct sta_info {
 		bool below_snr;
 	} band_steering;
 
+	uint8_t transition_request_count;
+	uint64_t transition_request_start;
+	uint64_t transition_request_last;
 	uint64_t kick_time;
 
 	int kick_count;


### PR DESCRIPTION
I've observed a Pixel 7 perform a bss transition even without disassociation_imminent, but a OnePlus 6 is slower to transition (usually only after about ~10s since the first bss transition request with `disassociation_imminent=false`, but usually switches before `disassociation_imminent=true`.)