### PR TITLE
policy: Account for band steering when selecting candidates

### DIFF
--- a/band_steering.c
+++ b/band_steering.c
@@ -24,25 +24,41 @@ void usteer_band_steering_sta_update(struct sta_info *si)
 		si->band_steering.below_snr = true;
 }
 
-bool usteer_band_steering_is_target(struct usteer_local_node *ln, struct usteer_node *node)
+static bool band_steering_is_target(struct usteer_node *cur, struct usteer_node *new)
 {
-	if (&ln->node == node)
+	if (cur == new)
 		return false;
 
-	if (strcmp(ln->node.ssid, node->ssid))
+	if (strcmp(cur->ssid, new->ssid))
 		return false;
 
-	if (node->freq < 4000)
+	if (new->freq < 4000)
 		return false;
 
-	if (!usteer_policy_node_below_max_assoc(node))
+	if (!usteer_policy_node_below_max_assoc(new))
 		return false;
 	
 	/* ToDo: Skip nodes with active load-kick */
 	
 	return true;
- }
+}
 
+bool usteer_band_steering_is_target(struct usteer_local_node *ln, struct usteer_node *node)
+{
+	return band_steering_is_target(&ln->node, node);
+}
+
+/* Checks if the configuration will band steer from the current station to the new one */
+bool usteer_will_band_steer(struct sta_info *si_cur, struct sta_info *si_new)
+{
+	if (!config.band_steering_interval)
+		return false;
+
+	if (si_cur->node->freq >= 4000)
+		return false;
+
+	return band_steering_is_target(si_cur->node, si_new->node);
+}
 
 static bool usteer_band_steering_has_target_iface(struct usteer_local_node *ln)
 {

--- a/policy.c
+++ b/policy.c
@@ -104,7 +104,9 @@ is_better_candidate(struct sta_info *si_cur, struct sta_info *si_new)
 	    !below_assoc_threshold(new_node, current_node))
 		reasons |= (1 << UEV_SELECT_REASON_NUM_ASSOC);
 
-	if (better_signal_strength(current_signal, new_signal))
+	/* If band steering will bounce us back, ignore comparing the signal (note flipped si_new, si_cur) */
+	if (!usteer_will_band_steer(si_new, si_cur) &&
+	    better_signal_strength(current_signal, new_signal))
 		reasons |= (1 << UEV_SELECT_REASON_SIGNAL);
 
 	if (has_better_load(current_node, new_node) &&
@@ -146,7 +148,7 @@ find_better_candidate(struct sta_info *si_ref, struct uevent *ev, uint32_t requi
 			ev->select_reasons = reasons;
 		}
 
-		if (!candidate || si->signal > candidate->signal)
+		if (!candidate || (is_better_candidate(candidate, si) && si->signal > candidate->signal))
 			candidate = si;
 	}
 

--- a/usteer.h
+++ b/usteer.h
@@ -332,6 +332,7 @@ bool usteer_policy_can_perform_roam(struct sta_info *si);
 void usteer_band_steering_perform_steer(struct usteer_local_node *ln);
 void usteer_band_steering_sta_update(struct sta_info *si);
 bool usteer_band_steering_is_target(struct usteer_local_node *ln, struct usteer_node *node);
+bool usteer_will_band_steer(struct sta_info *si_cur, struct sta_info *si_new);
 
 void usteer_ubus_init(struct ubus_context *ctx);
 void usteer_ubus_kick_client(struct sta_info *si);


### PR DESCRIPTION
When choosing a better candidate for a client to roam to, consider the fact that the the client may also be band-steered to a different frequency after association.

If the new AP has `assoc_steering` enabled, this may cause the client to attempt association, and fail associating which results in a kick from the original AP. This will cause the client to lose its association with the ESS.