### PR TITLE
Updates Roaming and Band-Steering

### DIFF
--- a/band_steering.c
+++ b/band_steering.c
@@ -20,6 +20,29 @@
 
 void usteer_band_steering_sta_update(struct sta_info *si)
 {
+	if (si->connected == STA_NOT_CONNECTED) {
+		if (si->band_steering.signal_threshold != NO_SIGNAL) {
+			si->band_steering.signal_threshold = NO_SIGNAL;
+		}
+		return;
+	}
+	if (config.band_steering_signal_threshold)
+	{
+		if (si->connected != STA_NOT_CONNECTED && si->band_steering.signal_threshold == NO_SIGNAL)
+		{
+			si->band_steering.signal_threshold = si->signal;
+			MSG(DEBUG, "band steering station " MAC_ADDR_FMT " (%s) set threshold %d\n", MAC_ADDR_DATA(si->sta->addr), usteer_node_name(si->node), si->band_steering.signal_threshold);
+			return;
+		}
+
+		/* Adapt signal threshold to actual signal quality */
+		if (si->signal < si->band_steering.signal_threshold) {
+			si->band_steering.signal_threshold--;
+			MSG(DEBUG, "band steering station " MAC_ADDR_FMT " (%s) reduce threshold %d, signal: %d\n", MAC_ADDR_DATA(si->sta->addr), usteer_node_name(si->node), si->band_steering.signal_threshold, si->signal);
+		}
+		if (si->signal < si->band_steering.signal_threshold + config.band_steering_signal_threshold)
+			si->band_steering.below_snr = true;
+	}
 	if (si->signal < usteer_snr_to_signal(si->node, config.band_steering_min_snr))
 		si->band_steering.below_snr = true;
 }

--- a/main.c
+++ b/main.c
@@ -97,6 +97,7 @@ void usteer_init_defaults(void)
 	config.initial_connect_delay = 0;
 	config.remote_node_timeout = 10;
 	config.aggressiveness = 3;
+	config.reassociation_delay = 30;
 
 	config.steer_reject_timeout = 60000;
 

--- a/main.c
+++ b/main.c
@@ -100,8 +100,9 @@ void usteer_init_defaults(void)
 
 	config.steer_reject_timeout = 60000;
 
-	config.band_steering_interval = 120000;
+	config.band_steering_interval = 30000;
 	config.band_steering_min_snr = -60;
+	config.band_steering_signal_threshold = 5;
 
 	config.link_measurement_interval = 30000;
 

--- a/main.c
+++ b/main.c
@@ -96,6 +96,7 @@ void usteer_init_defaults(void)
 	config.remote_update_interval = 1000;
 	config.initial_connect_delay = 0;
 	config.remote_node_timeout = 10;
+	config.aggressiveness = 3;
 
 	config.steer_reject_timeout = 60000;
 

--- a/openwrt/usteer/files/etc/config/usteer
+++ b/openwrt/usteer/files/etc/config/usteer
@@ -80,6 +80,9 @@ config usteer
 	# 4 = BSS-transition-request with disassociation imminent, timer and forced disassociation
 	#option aggressiveness 3
 
+	# Timeout (s in "1024ms") a station is requested to avoid reassociation after bss transition
+	#option reassociation_delay 30
+
 	# List of MACs (lower case) to set aggressiveness per station (ff:ff:ff:ff:ff,2)
 	#list aggressiveness_mac_list ''
 

--- a/openwrt/usteer/files/etc/config/usteer
+++ b/openwrt/usteer/files/etc/config/usteer
@@ -1,4 +1,6 @@
 config usteer
+	# OpenWrt guide: https://openwrt.org/docs/guide-user/network/wifi/usteer
+
 	# The network interface for inter-AP communication
 	option 'network' 'lan'
 
@@ -70,6 +72,16 @@ config usteer
 
 	# Timeout (ms) for which a client will not be steered after rejecting a BSS-transition-request
 	#option steer_reject_timeout 60000
+
+	# Aggressiveness of BSS-transition-request to push a station to another node (AP or band)
+	# 0 = no active transition / 1 = passive BSS-transition-request
+	# 2 = BSS-transition-request with disassociation imminent
+	# 3 = BSS-transition-request with disassociation imminent and timer
+	# 4 = BSS-transition-request with disassociation imminent, timer and forced disassociation
+	#option aggressiveness 3
+
+	# List of MACs (lower case) to set aggressiveness per station (ff:ff:ff:ff:ff,2)
+	#list aggressiveness_mac_list ''
 
 	# Timeout (in ms) after which a association following a disassociation is not seen
 	# as a roam

--- a/openwrt/usteer/files/etc/config/usteer
+++ b/openwrt/usteer/files/etc/config/usteer
@@ -134,11 +134,16 @@ config usteer
 
 	# Attempting to steer clients to a higher frequency-band every n ms.
 	# A value of 0 disabled band-steering.
-	#option band_steering_interval 120000
+	#option band_steering_interval 30000
 
 	# Minimal SNR or absolute signal a device has to maintain over band_steering_interval to be
 	# steered to a higher frequency band
 	#option band_steering_min_snr -60
+
+	# SNR difference that the signal must be better compared to signal was on connection to node.
+	# Avoids conflicts between roaming and band-steering policies.
+	# A value of 0 disables threshold.
+	#option band_steering_signal_threshold 5
 
 	# Interval (ms) the device is sent a link-measurement request to help assess
 	# the bi-directional link quality. Setting the interval to 0 disables link-measurements.

--- a/openwrt/usteer/files/etc/init.d/usteer
+++ b/openwrt/usteer/files/etc/init.d/usteer
@@ -84,9 +84,9 @@ uci_usteer() {
 		min_connect_snr min_snr min_snr_kick_delay signal_diff_threshold \
 		initial_connect_delay steer_reject_timeout roam_process_timeout\
 		roam_kick_delay roam_scan_tries roam_scan_timeout \
-		roam_scan_snr roam_scan_interval \
-		roam_trigger_snr roam_trigger_interval \
-		band_steering_interval band_steering_min_snr link_measurement_interval \
+		roam_scan_snr roam_scan_interval roam_trigger_snr roam_trigger_interval \
+		link_measurement_interval \
+		band_steering_interval band_steering_min_snr band_steering_signal_threshold \
 		load_kick_threshold load_kick_delay load_kick_min_clients \
 		load_kick_reason_code
 	do

--- a/openwrt/usteer/files/etc/init.d/usteer
+++ b/openwrt/usteer/files/etc/init.d/usteer
@@ -71,13 +71,14 @@ uci_usteer() {
 	uci_option_to_json_bool "$cfg" assoc_steering
 	uci_option_to_json_string "$cfg" node_up_script
 	uci_option_to_json_string_array "$cfg" ssid_list
+	uci_option_to_json_string_array "$cfg" aggressiveness_mac_list
 	uci_option_to_json_string_array "$cfg" event_log_types
 
 	for opt in \
 		debug_level \
 		sta_block_timeout local_sta_timeout local_sta_update \
 		max_neighbor_reports max_retry_band seen_policy_timeout \
-		measurement_report_timeout \
+		aggressiveness measurement_report_timeout \
 		load_balancing_threshold band_steering_threshold \
 		remote_update_interval remote_node_timeout\
 		min_connect_snr min_snr min_snr_kick_delay signal_diff_threshold \

--- a/policy.c
+++ b/policy.c
@@ -524,7 +524,7 @@ usteer_local_node_snr_kick(struct usteer_local_node *ln)
 		ev.count = si->kick_count;
 		usteer_event(&ev);
 
-		usteer_ubus_kick_client(si);
+		usteer_ubus_kick_client(si, KICK_REASON_UNSPECIFIED);
 		return;
 	}
 }
@@ -608,7 +608,7 @@ usteer_local_node_load_kick(struct usteer_local_node *ln)
 	ev.si_other = candidate;
 	ev.count = kick1->kick_count;
 
-	usteer_ubus_kick_client(kick1);
+	usteer_ubus_kick_client(kick1, config.load_kick_reason_code);
 
 out:
 	usteer_event(&ev);
@@ -623,7 +623,7 @@ usteer_local_node_perform_kick(struct usteer_local_node *ln)
 		if (!si->kick_time || si->kick_time > current_time)
 			continue;
 
-		usteer_ubus_kick_client(si);
+		usteer_ubus_kick_client(si, KICK_REASON_BSS_TRANSITION);
 	}
 }
 

--- a/ubus.c
+++ b/ubus.c
@@ -773,13 +773,13 @@ int usteer_ubus_trigger_client_scan(struct sta_info *si)
 	return ubus_invoke(ubus_ctx, ln->obj_id, "rrm_beacon_req", b.head, NULL, 0, 100);
 }
 
-void usteer_ubus_kick_client(struct sta_info *si)
+void usteer_ubus_kick_client(struct sta_info *si, uint32_t kick_reason_code)
 {
 	struct usteer_local_node *ln = container_of(si->node, struct usteer_local_node, node);
 
 	blob_buf_init(&b, 0);
 	blobmsg_printf(&b, "addr", MAC_ADDR_FMT, MAC_ADDR_DATA(si->sta->addr));
-	blobmsg_add_u32(&b, "reason", config.load_kick_reason_code);
+	blobmsg_add_u32(&b, "reason", kick_reason_code);
 	blobmsg_add_u8(&b, "deauth", 1);
 	ubus_invoke(ubus_ctx, ln->obj_id, "del_client", b.head, NULL, 0, 100);
 	usteer_sta_disconnected(si);

--- a/ubus.c
+++ b/ubus.c
@@ -162,6 +162,9 @@ struct cfg_item {
 	_cfg(U32, remote_update_interval), \
 	_cfg(U32, remote_node_timeout), \
 	_cfg(BOOL, assoc_steering), \
+	_cfg(U32, aggressiveness), \
+	_cfg(ARRAY_CB, aggressiveness_mac_list), \
+	_cfg(U32, aggressive_disassoc_timer), \
 	_cfg(I32, min_connect_snr), \
 	_cfg(I32, min_snr), \
 	_cfg(U32, min_snr_kick_delay), \
@@ -668,11 +671,12 @@ usteer_ubus_disassoc_add_neighbors(struct sta_info *si)
 }
 
 int usteer_ubus_bss_transition_request(struct sta_info *si,
-				       uint8_t dialog_token,
-				       bool disassoc_imminent,
-				       bool abridged,
-				       uint8_t validity_period,
-				       struct usteer_node *target_node)
+                                       uint8_t dialog_token,
+                                       bool disassoc_imminent,
+                                       uint32_t disassoc_timer,
+                                       bool abridged,
+                                       uint8_t validity_period,
+                                       struct usteer_node *target_node)
 {
 	struct usteer_local_node *ln = container_of(si->node, struct usteer_local_node, node);
 
@@ -680,17 +684,29 @@ int usteer_ubus_bss_transition_request(struct sta_info *si,
 	blobmsg_printf(&b, "addr", MAC_ADDR_FMT, MAC_ADDR_DATA(si->sta->addr));
 	blobmsg_add_u32(&b, "dialog_token", dialog_token);
 	blobmsg_add_u8(&b, "disassociation_imminent", disassoc_imminent);
+	if (disassoc_imminent) {
+		blobmsg_add_u32(&b, "disassociation_timer", disassoc_timer);
+	}
 	blobmsg_add_u8(&b, "abridged", abridged);
 	blobmsg_add_u32(&b, "validity_period", validity_period);
+
 	if (!target_node) {
+		/* Add all known neighbors if no specific target set */
+		MSG(VERBOSE, "roaming station " MAC_ADDR_FMT " without target\n", MAC_ADDR_DATA(si->sta->addr));
 		usteer_ubus_disassoc_add_neighbors(si);
 	} else {
+		MSG(VERBOSE, "roaming station " MAC_ADDR_FMT " to " MAC_ADDR_FMT " (%s) disassociation timer %u, signal %d\n", MAC_ADDR_DATA(si->sta->addr), MAC_ADDR_DATA(target_node->bssid), usteer_node_name(target_node), disassoc_timer, si->signal);
 		usteer_ubus_disassoc_add_neighbor(si, target_node);
 	}
 	return ubus_invoke(ubus_ctx, ln->obj_id, "bss_transition_request", b.head, NULL, 0, 100);
 }
 
-int usteer_ubus_band_steering_request(struct sta_info *si)
+int usteer_ubus_band_steering_request(struct sta_info *si,
+                                      uint8_t dialog_token,
+                                      bool disassoc_imminent,
+                                      uint32_t disassoc_timer,
+                                      bool abridged,
+                                      uint8_t validity_period)
 {
 	struct usteer_local_node *ln = container_of(si->node, struct usteer_local_node, node);
 	struct usteer_node *node;
@@ -698,10 +714,13 @@ int usteer_ubus_band_steering_request(struct sta_info *si)
 
 	blob_buf_init(&b, 0);
 	blobmsg_printf(&b, "addr", MAC_ADDR_FMT, MAC_ADDR_DATA(si->sta->addr));
-	blobmsg_add_u32(&b, "dialog_token", 0);
-	blobmsg_add_u8(&b, "disassociation_imminent", false);
-	blobmsg_add_u8(&b, "abridged", false);
-	blobmsg_add_u32(&b, "validity_period", 100);
+	blobmsg_add_u32(&b, "dialog_token", dialog_token);
+	blobmsg_add_u8(&b, "disassociation_imminent", disassoc_imminent);
+	if (disassoc_imminent) {
+		blobmsg_add_u32(&b, "disassociation_timer", disassoc_timer);
+	}
+	blobmsg_add_u8(&b, "abridged", abridged);
+	blobmsg_add_u32(&b, "validity_period", validity_period);
 
 	c = blobmsg_open_array(&b, "neighbors");
 	for_each_local_node(node) {
@@ -709,10 +728,14 @@ int usteer_ubus_band_steering_request(struct sta_info *si)
 			continue;
 	
 		usteer_add_nr_entry(si->node, node);
+		MSG(DEBUG, "band steering station " MAC_ADDR_FMT " adding neighbor " MAC_ADDR_FMT " (%s)\n", MAC_ADDR_DATA(si->sta->addr), MAC_ADDR_DATA(node->bssid), usteer_node_name(node));
 	}
 	blobmsg_close_array(&b, c);
-
-	return ubus_invoke(ubus_ctx, ln->obj_id, "bss_transition_request", b.head, NULL, 0, 100);
+	if (sizeof(si->node) > 0) {
+		MSG(VERBOSE, "band steering station " MAC_ADDR_FMT " disassociation timer %u, signal %d\n", MAC_ADDR_DATA(si->sta->addr), disassoc_timer, si->signal);
+		return ubus_invoke(ubus_ctx, ln->obj_id, "bss_transition_request", b.head, NULL, 0, 100);
+	} else
+		MSG(VERBOSE, "band steering no targets found for station " MAC_ADDR_FMT "\n", MAC_ADDR_DATA(si->sta->addr));
 }
 
 int usteer_ubus_trigger_link_measurement(struct sta_info *si)

--- a/ubus.c
+++ b/ubus.c
@@ -686,9 +686,11 @@ int usteer_ubus_bss_transition_request(struct sta_info *si,
 	blobmsg_add_u8(&b, "disassociation_imminent", disassoc_imminent);
 	if (disassoc_imminent) {
 		blobmsg_add_u32(&b, "disassociation_timer", disassoc_timer);
+		blobmsg_add_u32(&b, "reassoc_delay", config.reassociation_delay);
 	}
 	blobmsg_add_u8(&b, "abridged", abridged);
 	blobmsg_add_u32(&b, "validity_period", validity_period);
+	blobmsg_add_u32(&b, "mbo_reason", 5);
 
 	if (!target_node) {
 		/* Add all known neighbors if no specific target set */
@@ -718,9 +720,11 @@ int usteer_ubus_band_steering_request(struct sta_info *si,
 	blobmsg_add_u8(&b, "disassociation_imminent", disassoc_imminent);
 	if (disassoc_imminent) {
 		blobmsg_add_u32(&b, "disassociation_timer", disassoc_timer);
+		blobmsg_add_u32(&b, "reassoc_delay", config.reassociation_delay);
 	}
 	blobmsg_add_u8(&b, "abridged", abridged);
 	blobmsg_add_u32(&b, "validity_period", validity_period);
+	blobmsg_add_u32(&b, "mbo_reason", 5);
 
 	c = blobmsg_open_array(&b, "neighbors");
 	for_each_local_node(node) {

--- a/usteer.h
+++ b/usteer.h
@@ -180,6 +180,7 @@ struct usteer_config {
 	uint32_t aggressiveness;
 	struct blob_attr *aggressiveness_mac_list;
 	uint32_t aggressive_disassoc_timer;
+	uint32_t reassociation_delay;
 
 	int32_t min_snr;
 	uint32_t min_snr_kick_delay;

--- a/usteer.h
+++ b/usteer.h
@@ -202,6 +202,7 @@ struct usteer_config {
 
 	uint32_t band_steering_interval;
 	int32_t band_steering_min_snr;
+	uint32_t band_steering_signal_threshold;
 
 	uint32_t link_measurement_interval;
 
@@ -278,6 +279,7 @@ struct sta_info {
 
 	struct {
 		bool below_snr;
+		int signal_threshold;
 	} band_steering;
 
 	uint64_t kick_time;

--- a/usteer.h
+++ b/usteer.h
@@ -66,6 +66,13 @@ enum usteer_beacon_measurement_mode {
 	BEACON_MEASUREMENT_TABLE = 2,
 };
 
+enum usteer_kick_reason_code
+{
+	KICK_REASON_UNSPECIFIED = 1,
+	KICK_REASON_LOAD = 5,
+	KICK_REASON_BSS_TRANSITION = 12,
+};
+
 struct sta_info;
 struct usteer_local_node;
 struct usteer_remote_host;
@@ -342,7 +349,7 @@ void usteer_band_steering_sta_update(struct sta_info *si);
 bool usteer_band_steering_is_target(struct usteer_local_node *ln, struct usteer_node *node);
 
 void usteer_ubus_init(struct ubus_context *ctx);
-void usteer_ubus_kick_client(struct sta_info *si);
+void usteer_ubus_kick_client(struct sta_info *si, uint32_t kick_reason_code);
 int usteer_ubus_trigger_client_scan(struct sta_info *si);
 int usteer_ubus_band_steering_request(struct sta_info *si,
                                       uint8_t dialog_token,

--- a/usteer.h
+++ b/usteer.h
@@ -170,6 +170,10 @@ struct usteer_config {
 	uint32_t remote_update_interval;
 	uint32_t remote_node_timeout;
 
+	uint32_t aggressiveness;
+	struct blob_attr *aggressiveness_mac_list;
+	uint32_t aggressive_disassoc_timer;
+
 	int32_t min_snr;
 	uint32_t min_snr_kick_delay;
 	int32_t min_connect_snr;
@@ -190,7 +194,7 @@ struct usteer_config {
 	uint32_t roam_kick_delay;
 
 	uint32_t band_steering_interval;
-	int32_t band_steering_min_snr; 
+	int32_t band_steering_min_snr;
 
 	uint32_t link_measurement_interval;
 
@@ -254,6 +258,8 @@ struct sta_info {
 	enum roam_trigger_state roam_state;
 	uint8_t roam_tries;
 	uint64_t roam_event;
+	uint64_t roam_transition_request_validity_end;
+	uint64_t roam_transition_start;
 	uint64_t roam_kick;
 	uint64_t roam_scan_start;
 	uint64_t roam_scan_timeout_start;
@@ -284,6 +290,8 @@ struct sta {
 
 	uint8_t seen_2ghz : 1;
 	uint8_t seen_5ghz : 1;
+
+	uint32_t aggressiveness;
 
 	uint8_t addr[6];
 };
@@ -336,13 +344,19 @@ bool usteer_band_steering_is_target(struct usteer_local_node *ln, struct usteer_
 void usteer_ubus_init(struct ubus_context *ctx);
 void usteer_ubus_kick_client(struct sta_info *si);
 int usteer_ubus_trigger_client_scan(struct sta_info *si);
-int usteer_ubus_band_steering_request(struct sta_info *si);
+int usteer_ubus_band_steering_request(struct sta_info *si,
+                                      uint8_t dialog_token,
+                                      bool disassoc_imminent,
+                                      uint32_t disassoc_timer,
+                                      bool abridged,
+                                      uint8_t validity_period);
 int usteer_ubus_bss_transition_request(struct sta_info *si,
-				       uint8_t dialog_token,
-				       bool disassoc_imminent,
-				       bool abridged,
-				       uint8_t validity_period,
-				       struct usteer_node *target_node);
+                                       uint8_t dialog_token,
+                                       bool disassoc_imminent,
+                                       uint32_t disassoc_timer,
+                                       bool abridged,
+                                       uint8_t validity_period,
+                                       struct usteer_node *target_node);
 
 struct sta *usteer_sta_get(const uint8_t *addr, bool create);
 struct sta_info *usteer_sta_info_get(struct sta *sta, struct usteer_node *node, bool *create);
@@ -375,6 +389,9 @@ void config_get_node_up_script(struct blob_buf *buf);
 
 void config_set_ssid_list(struct blob_attr *data);
 void config_get_ssid_list(struct blob_buf *buf);
+
+void config_set_aggressiveness_mac_list(struct blob_attr *data);
+void config_get_aggressiveness_mac_list(struct blob_buf *buf);
 
 int usteer_interface_init(void);
 void usteer_interface_add(const char *name);


### PR DESCRIPTION
Adds some central new functions:

- flexible setting how aggressive the roaming is done - works better with some devices like some Intel Wifi Cards and also Apple
- band steering could be checked more frequently as the steering depends on the quality change of the signal itself
- Small fixes like DEAUTH reason, etc.
- Additional log message to understand roaming behavior easier from user perspective