### PR TITLE
Added a list of station to be ignored

### DIFF
--- a/local_node.c
+++ b/local_node.c
@@ -977,6 +977,46 @@ void config_get_ssid_list(struct blob_buf *buf)
 		blobmsg_add_blob(buf, config.ssid_list);
 }
 
+void config_set_ignored_stations(struct blob_attr *data)
+{
+	int i = 0;
+	const char *val;
+
+	if (!data)
+		return;
+
+	val = blobmsg_get_string(data);
+
+	if (config.ignored_stations)
+		free(config.ignored_stations);
+
+	if (!strlen(val)) {
+		config.ignored_stations = NULL;
+		return;
+	}
+
+	config.ignored_stations = malloc(strlen(val));
+	for (i = 0; i < strlen(val); i++)
+	{
+		if ((val[i] >= 'a') && (val[i] <= 'z'))
+			config.ignored_stations[i] = val[i] + 'A' - 'a';
+		else
+			config.ignored_stations[i] = val[i];
+	}
+
+	config.ignored_stations[i] = 0;
+
+	debug_msg(MSG_DEBUG, "config_set_ignored_stations", 1009, "Station to be ignored: %s", config.ignored_stations);
+}
+
+void config_get_ignored_stations(struct blob_buf *buf)
+{
+	if (!config.ignored_stations)
+		return;
+
+	blobmsg_add_string(buf, "ignored_stations", config.ignored_stations);
+}
+
 void
 usteer_local_nodes_init(struct ubus_context *ctx)
 {

--- a/openwrt/usteer/files/etc/config/usteer
+++ b/openwrt/usteer/files/etc/config/usteer
@@ -151,5 +151,8 @@ config usteer
 	# - signal_kick
 	#list event_log_types ''
 
+	# MAC Address to ignore
+	#option ignored_stations ''
+
 	# List of SSIDs to enable steering on
 	#list ssid_list ''

--- a/openwrt/usteer/files/etc/init.d/usteer
+++ b/openwrt/usteer/files/etc/init.d/usteer
@@ -70,6 +70,7 @@ uci_usteer() {
 	uci_option_to_json_bool "$cfg" load_kick_enabled
 	uci_option_to_json_bool "$cfg" assoc_steering
 	uci_option_to_json_string "$cfg" node_up_script
+	uci_option_to_json_string "$cfg" ignored_stations
 	uci_option_to_json_string_array "$cfg" ssid_list
 	uci_option_to_json_string_array "$cfg" event_log_types
 

--- a/ubus.c
+++ b/ubus.c
@@ -187,6 +187,7 @@ struct cfg_item {
 	_cfg(ARRAY_CB, interfaces), \
 	_cfg(STRING_CB, node_up_script), \
 	_cfg(ARRAY_CB, event_log_types), \
+	_cfg(STRING_CB, ignored_stations), \
 	_cfg(ARRAY_CB, ssid_list)
 
 enum cfg_items {

--- a/usteer.h
+++ b/usteer.h
@@ -205,6 +205,8 @@ struct usteer_config {
 	const char *node_up_script;
 	uint32_t event_log_mask;
 
+	char *ignored_stations;
+
 	struct blob_attr *ssid_list;
 };
 
@@ -375,6 +377,9 @@ void config_get_node_up_script(struct blob_buf *buf);
 
 void config_set_ssid_list(struct blob_attr *data);
 void config_get_ssid_list(struct blob_buf *buf);
+
+void config_set_ignored_stations(struct blob_attr *data);
+void config_get_ignored_stations(struct blob_buf *buf);
 
 int usteer_interface_init(void);
 void usteer_interface_add(const char *name);


### PR DESCRIPTION
I had problems using usteer with some devices like Google Home Mini.
They are kicked out by usteer (I can't understand why, probably due to inactivity) and they remain disconnected until reboot.
So I add a configuration parameter with a list of MAC Addresse to "ingore" these stations during usteer process for roaming, band stearing or 'kick out' 