### PR TITLE
usteer: fix memory leak / bad condition

### DIFF
--- a/local_node.c
+++ b/local_node.c
@@ -132,8 +132,10 @@ usteer_handle_bss_tm_query(struct usteer_local_node *ln, struct blob_attr *msg)
 	query->dialog_token = blobmsg_get_u8(tb[BSS_TM_QUERY_DIALOG_TOKEN]);
 
 	sta_addr = (uint8_t *) ether_aton(blobmsg_get_string(tb[BSS_TM_QUERY_ADDRESS]));
-	if (!sta_addr)
+	if (!sta_addr) {
+		free(query);
 		return 0;
+	}
 
 	memcpy(query->sta_addr, sta_addr, 6);
 

--- a/policy.c
+++ b/policy.c
@@ -108,7 +108,7 @@ is_better_candidate(struct sta_info *si_cur, struct sta_info *si_new)
 		reasons |= (1 << UEV_SELECT_REASON_SIGNAL);
 
 	if (has_better_load(current_node, new_node) &&
-		!has_better_load(current_node, new_node))
+		!has_better_load(new_node, current_node))
 		reasons |= (1 << UEV_SELECT_REASON_LOAD);
 
 	return reasons;


### PR DESCRIPTION
Fixed a potential memory leak in `usteer_handle_bss_tm_query` by freeing the `query` object before returning when `sta_addr` is invalid. Corrected the load comparison logic in `is_better_candidate` to ensure that the function properly compares the load between nodes, using the correct argument order for `has_better_load` otherwise its always false.