### PR TITLE
Optimizations for band steering and config defaults / bug fixes to aggressive roaming and socket handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ usteer is available from the OpenWrt packages feed and can be installed on devic
 opkg update; opkg install usteer
 ```
 
+You can find the complete documentation for setting everything up and getting it running here:[OpenWRT documentation](https://openwrt.org/docs/guide-user/network/wifi/usteer).
+
+### Config recommendation
+The default settings are the best in most environments (many users overdo optimizations to it) to support roaming and band steering. At best nothing has to be configured but take care that usteer communication is not done on a public network.
+
+
 ## Submitting patches
 
 usteer patches are welcome on the openwrt-devel mailing list.

--- a/band_steering.c
+++ b/band_steering.c
@@ -26,6 +26,11 @@ void usteer_band_steering_sta_update(struct sta_info *si)
 		}
 		return;
 	}
+	if (si->node->freq >= 4000)
+		return;
+	if (!si->sta->seen_5ghz)
+		return;
+
 	if (config.band_steering_signal_threshold)
 	{
 		if (si->connected != STA_NOT_CONNECTED && si->band_steering.signal_threshold == NO_SIGNAL)
@@ -106,6 +111,10 @@ void usteer_band_steering_perform_steer(struct usteer_local_node *ln)
 	ln->band_steering_interval = 0;
 
 	list_for_each_entry(si, &ln->node.sta_info, node_list) {
+		/* Check if client supports 5Ghz */
+		if (!si->sta->seen_5ghz)
+			continue;
+
 		/* Check if client is eligable to be steerd */
 		if (!usteer_policy_can_perform_roam(si))
 			continue;

--- a/main.c
+++ b/main.c
@@ -100,6 +100,7 @@ void usteer_init_defaults(void)
 	config.signal_diff_threshold = 8;
 	config.band_steering_threshold = 5;
 	config.load_balancing_threshold = 0;
+	config.local_mode = 0;
 	config.remote_update_interval = 1000;
 	config.initial_connect_delay = 0;
 	config.remote_node_timeout = 10;

--- a/main.c
+++ b/main.c
@@ -84,6 +84,12 @@ void usteer_init_defaults(void)
 {
 	memset(&config, 0, sizeof(config));
 
+	config.syslog = true;
+	config.debug_level = MSG_FATAL;
+	
+	config.ipv6 = false;
+	config.local_mode = 0;
+
 	config.sta_block_timeout = 30 * 1000;
 	config.local_sta_timeout = 120 * 1000;
 	config.measurement_report_timeout = 120 * 1000;
@@ -91,6 +97,7 @@ void usteer_init_defaults(void)
 	config.max_retry_band = 5;
 	config.max_neighbor_reports = 8;
 	config.seen_policy_timeout = 30 * 1000;
+	config.signal_diff_threshold = 8;
 	config.band_steering_threshold = 5;
 	config.load_balancing_threshold = 0;
 	config.remote_update_interval = 1000;
@@ -99,22 +106,24 @@ void usteer_init_defaults(void)
 	config.aggressiveness = 3;
 	config.reassociation_delay = 30;
 
-	config.steer_reject_timeout = 60000;
+	config.steer_reject_timeout = 60 * 1000;
 
-	config.band_steering_interval = 30000;
+	config.band_steering_interval = 30 * 1000;
 	config.band_steering_min_snr = -60;
 	config.band_steering_signal_threshold = 5;
 
-	config.link_measurement_interval = 30000;
+	config.link_measurement_interval = 30 * 1000;
 
 	config.probe_steering = 0;
 
-	config.roam_kick_delay = 10000;
+	config.roam_kick_delay = 10 * 1000;
 	config.roam_process_timeout = 5 * 1000;
 	config.roam_scan_tries = 3;
 	config.roam_scan_timeout = 0;
 	config.roam_scan_interval = 10 * 1000;
-	config.roam_trigger_interval = 60 * 1000;
+	config.roam_scan_snr = -65;
+	config.roam_trigger_interval = 30 * 1000;
+	config.roam_trigger_snr = 0;
 
 	config.min_snr_kick_delay = 5 * 1000;
 
@@ -123,8 +132,6 @@ void usteer_init_defaults(void)
 	config.load_kick_delay = 10 * 1000;
 	config.load_kick_min_clients = 10;
 	config.load_kick_reason_code = 5; /* WLAN_REASON_DISASSOC_AP_BUSY */
-
-	config.debug_level = MSG_FATAL;
 }
 
 void usteer_update_time(void)

--- a/openwrt/usteer/files/etc/config/usteer
+++ b/openwrt/usteer/files/etc/config/usteer
@@ -5,13 +5,13 @@ config usteer
 	option 'network' 'lan'
 
 	# Log messages to syslog (0/1)
-	option 'syslog' '1'
+	#option 'syslog' '1'
 
 	# Disable network communication (0/1)
-	option local_mode '0'
+	#option local_mode '0'
 
 	# Use IPv6 for remote exchange
-	option 'ipv6' '0'
+	#option 'ipv6' '0'
 
 	# Minimum level of logged messages
 	# 0 = fatal
@@ -20,7 +20,7 @@ config usteer
 	# 3 = some debug messages
 	# 4 = network packet information
 	# 5 = all debug messages
-	option 'debug_level' '2'
+	#option 'debug_level' '2'
 
 	# Maximum number of neighbor reports set for a node
 	#option max_neighbor_reports 8
@@ -96,7 +96,7 @@ config usteer
 	# Maximum signal-to-noise ratio or signal level (dBm) before attempting to trigger
 	# client scans for roaming
 	# Related: should be higher than `roam_trigger_snr`
-	#option roam_scan_snr 0
+	#option roam_scan_snr -65
 
 	# Maximum number of client roaming scan trigger attempts
 	#option roam_scan_tries 3
@@ -114,13 +114,13 @@ config usteer
 	#option roam_trigger_snr 0
 
 	# Minimum time (ms) between client roaming trigger attempts
-	#option roam_trigger_interval 60000
+	#option roam_trigger_interval 30000
 
 	# Timeout (ms) for client roam requests. usteer will kick the client after this times out.
 	#option roam_kick_delay 10000
 
 	# Minimum signal strength difference until AP steering policy is active
-	#option signal_diff_threshold 0
+	#option signal_diff_threshold 8
 
 	# Initial delay (ms) before responding to probe requests (to allow other APs to see packets as well)
 	#option initial_connect_delay 0

--- a/openwrt/usteer/files/etc/config/usteer
+++ b/openwrt/usteer/files/etc/config/usteer
@@ -44,6 +44,7 @@ config usteer
 	#option seen_policy_timeout 30000
 
 	# Minimum number of stations delta between APs before load balancing policy is active
+	# No effect unless load_balancing_threshold is above 0
 	#option load_balancing_threshold 0
 
 	# Minimum number of stations delta between bands before band steering policy is active
@@ -62,9 +63,11 @@ config usteer
 	#option probe_steering 0
 
 	# Minimum signal-to-noise ratio or signal level (dBm) to allow connections
+	# Related: should be equal to or higher than `min_snr` and `band_steering_min_snr`
 	#option min_connect_snr 0
 
 	# Minimum signal-to-noise ratio or signal level (dBm) to remain connected
+	# Related: should be equal to or lower than `min_connect_snr` and lower than `band_steering_min_snr`
 	#option min_snr 0
 
 	# Timeout after which a station with snr < min_snr will be kicked
@@ -90,8 +93,9 @@ config usteer
 	# as a roam
 	#option roam_process_timeout 5000
 
-	# Minimum signal-to-noise ratio or signal level (dBm) before attempting to trigger
+	# Maximum signal-to-noise ratio or signal level (dBm) before attempting to trigger
 	# client scans for roaming
+	# Related: should be higher than `roam_trigger_snr`
 	#option roam_scan_snr 0
 
 	# Maximum number of client roaming scan trigger attempts
@@ -104,8 +108,9 @@ config usteer
 	# Minimum time (ms) between client roaming scan trigger attempts
 	#option roam_scan_interval 10000
 
-	# Minimum signal-to-noise ratio or signal level (dBm) before attempting to trigger
+	# Maximum signal-to-noise ratio or signal level (dBm) before attempting to trigger
 	# forced client roaming
+	# Related: should be lower than `roam_scan_snr`
 	#option roam_trigger_snr 0
 
 	# Minimum time (ms) between client roaming trigger attempts
@@ -141,6 +146,7 @@ config usteer
 
 	# Minimal SNR or absolute signal a device has to maintain over band_steering_interval to be
 	# steered to a higher frequency band
+	# Related: should be above `min_connect_snr` and `min_snr`
 	#option band_steering_min_snr -60
 
 	# SNR difference that the signal must be better compared to signal was on connection to node.

--- a/policy.c
+++ b/policy.c
@@ -55,7 +55,7 @@ better_signal_strength(int signal_cur, int signal_new)
 }
 
 static bool
-below_load_threshold(struct usteer_node *node)
+above_load_threshold(struct usteer_node *node)
 {
 	return node->n_assoc >= config.load_kick_min_clients &&
 	       node->load > config.load_kick_threshold;
@@ -64,7 +64,7 @@ below_load_threshold(struct usteer_node *node)
 static bool
 has_better_load(struct usteer_node *node_cur, struct usteer_node *node_new)
 {
-	return !below_load_threshold(node_cur) && below_load_threshold(node_new);
+	return above_load_threshold(node_cur) && !above_load_threshold(node_new);
 }
 
 bool
@@ -107,8 +107,7 @@ is_better_candidate(struct sta_info *si_cur, struct sta_info *si_new)
 	if (better_signal_strength(current_signal, new_signal))
 		reasons |= (1 << UEV_SELECT_REASON_SIGNAL);
 
-	if (has_better_load(current_node, new_node) &&
-		!has_better_load(new_node, current_node))
+	if (has_better_load(current_node, new_node))
 		reasons |= (1 << UEV_SELECT_REASON_LOAD);
 
 	return reasons;

--- a/remote.c
+++ b/remote.c
@@ -749,6 +749,9 @@ static void usteer_reload_timer(struct uloop_timeout *t) {
 		close(remote_fd.fd);
 	}
 
+	if (config.local_mode)
+		return;
+
 	if (config.ipv6) {
 		remote_fd.fd = usteer_create_v6_socket();
 		remote_fd.cb = interface_recv_v6;
@@ -765,6 +768,8 @@ static void usteer_reload_timer(struct uloop_timeout *t) {
 
 int usteer_interface_init(void)
 {
+	if (config.local_mode)
+		return -1;
 	if (usteer_init_local_id())
 		return -1;
 

--- a/sta.c
+++ b/sta.c
@@ -17,6 +17,8 @@
  *   Copyright (C) 2020 John Crispin <john@phrozen.org> 
  */
 
+#include <ctype.h>
+#include <netinet/ether.h>
 #include "usteer.h"
 
 static int
@@ -81,11 +83,10 @@ usteer_sta_update_aggressiveness(struct sta *sta)
 {
 	struct blob_attr *cur;
 	int rem;
-	char sta_mac[18];
+	uint8_t *config_addr;
 	char config_entry[20];
 	char config_mac[18];
-	
-	sprintf(sta_mac, MAC_ADDR_FMT, MAC_ADDR_DATA(sta->addr));
+
 	sta->aggressiveness = config.aggressiveness;
 	blobmsg_for_each_attr(cur, config.aggressiveness_mac_list, rem) {
 		strcpy(config_entry, blobmsg_get_string(cur));
@@ -93,10 +94,22 @@ usteer_sta_update_aggressiveness(struct sta *sta)
 			continue;
 		strncpy(config_mac, config_entry, 18);
 		config_mac[17] = '\0';
-		if (strcmp(config_mac, sta_mac) != 0)
+		config_addr = (uint8_t *) ether_aton(config_mac);
+		if (memcmp(config_addr, sta->addr, 6) != 0)
 			continue;
 		sta->aggressiveness = config_entry[18] - '0';
+		MSG(DEBUG, "Set aggressiveness for station " MAC_ADDR_FMT " from config to %d\n",
+			MAC_ADDR_DATA(sta->addr), sta->aggressiveness);
 		break;
+	}
+}
+
+void
+usteer_sta_load_each_aggressiveness()
+{
+	struct sta *sta;
+	avl_for_each_element(&stations, sta, avl) {
+		usteer_sta_update_aggressiveness(sta);
 	}
 }
 
@@ -128,8 +141,6 @@ usteer_sta_info_get(struct sta *sta, struct usteer_node *node, bool *create)
 	list_add(&si->node_list, &node->sta_info);
 	si->created = current_time;
 	*create = true;
-
-	usteer_sta_update_aggressiveness(sta);
 
 	/* Node is by default not connected. */
 	usteer_sta_disconnected(si);
@@ -168,7 +179,7 @@ usteer_sta_get(const uint8_t *addr, bool create)
 	avl_insert(&stations, &sta->avl);
 	INIT_LIST_HEAD(&sta->nodes);
 	INIT_LIST_HEAD(&sta->measurements);
-
+	usteer_sta_update_aggressiveness(sta);
 	return sta;
 }
 

--- a/ubus.c
+++ b/ubus.c
@@ -163,8 +163,8 @@ struct cfg_item {
 	_cfg(U32, remote_node_timeout), \
 	_cfg(BOOL, assoc_steering), \
 	_cfg(U32, aggressiveness), \
+	_cfg(U32, reassociation_delay), \
 	_cfg(ARRAY_CB, aggressiveness_mac_list), \
-	_cfg(U32, aggressive_disassoc_timer), \
 	_cfg(I32, min_connect_snr), \
 	_cfg(I32, min_snr), \
 	_cfg(U32, min_snr_kick_delay), \
@@ -186,6 +186,7 @@ struct cfg_item {
 	_cfg(U32, load_kick_reason_code), \
 	_cfg(U32, band_steering_interval), \
 	_cfg(I32, band_steering_min_snr), \
+	_cfg(U32, band_steering_signal_threshold), \
 	_cfg(U32, link_measurement_interval), \
 	_cfg(ARRAY_CB, interfaces), \
 	_cfg(STRING_CB, node_up_script), \
@@ -285,6 +286,7 @@ usteer_ubus_set_config(struct ubus_context *ctx, struct ubus_object *obj,
 		}
 	}
 
+	usteer_sta_load_each_aggressiveness();
 	usteer_interface_init();
 
 	return 0;
@@ -471,6 +473,9 @@ usteer_ubus_get_connected_clients(struct ubus_context *ctx, struct ubus_object *
 				blobmsg_close_table(&b, t);
 			}
 			blobmsg_close_array(&b, a);
+
+			/* Aggressiveness */
+			blobmsg_add_u32(&b, "aggressiveness", si->sta->aggressiveness);
 
 			blobmsg_close_table(&b, s);
 		}

--- a/usteer.h
+++ b/usteer.h
@@ -371,6 +371,8 @@ int usteer_ubus_bss_transition_request(struct sta_info *si,
 struct sta *usteer_sta_get(const uint8_t *addr, bool create);
 struct sta_info *usteer_sta_info_get(struct sta *sta, struct usteer_node *node, bool *create);
 
+void usteer_sta_load_each_aggressiveness();
+
 bool usteer_sta_supports_beacon_measurement_mode(struct sta_info *si, enum usteer_beacon_measurement_mode mode);
 bool usteer_sta_supports_link_measurement(struct sta_info *si);
 


### PR DESCRIPTION
This PR continues the work started in https://github.com/openwrt/usteer/pull/10 and ports the last changes, improvements, and bug fixes from usteer‑ng back to the primary usteer project. The goal is to ensure that recent developments in usteer‑ng are available to all users of usteer.

### Optimizations

- Added default values for missing configuration items
- Harmonized the calculation of default values
- Added a new section to the README to help first‑time users set up usteer

### Bugs

- Stations without 5 GHz support sometimes attempted to steer to 5 GHz indefinitely. This is now prevented by requiring the station to connect to 5 GHz first. Later this should be replaced by using station metadata from UBUS to avoid this detection method.
- Avoided creating an unnecessary socket in local mode to improve security
- The load threshold was never applied due to a true == false check
- Syslog is the default logger during startup. During this phase, no logging occurred unless debugging was enabled because syslog must first be loaded by UBUS config interface.